### PR TITLE
Replaced deprecated syntax

### DIFF
--- a/src/StringLib.php
+++ b/src/StringLib.php
@@ -311,11 +311,11 @@ namespace iRAP\CoreLibs;
      */
     public static function sanitizeRegExp($regExp)
     {
-        $pattern_parts = explode($regExp{0}, trim($regExp));
+        $pattern_parts = explode($regExp[0], trim($regExp));
         $pattern_last = sizeof($pattern_parts) - 1;
         $pattern_parts[$pattern_last] = str_replace('e', '', $pattern_parts[$pattern_last]);
         
-        return implode($regExp{0}, $pattern_parts);
+        return implode($regExp[0], $pattern_parts);
     }
     
     


### PR DESCRIPTION
The {} array access notation does not work with php 8.0