### PR TITLE
json_encode(): Passing null to parameter #2 () of type int is deprecated

### DIFF
--- a/src/MysqliLib.php
+++ b/src/MysqliLib.php
@@ -263,7 +263,7 @@ class MysqliLib
      * @param Bitmask $jsonOptions - any options you wish to specify, such as JSON_HEX_QUOT
      * @throws Exception
      */
-    public static function convertResultToJsonFile(\mysqli_result $result, string $filepath, $jsonOptions=null)
+    public static function convertResultToJsonFile(\mysqli_result $result, string $filepath, $jsonOptions=0)
     {
         if ($result === FALSE)
         {


### PR DESCRIPTION
Passing 'null' to the json_encode method is deprecated.
Replaced default value for $jsonOptions in method call to 0.
3rd Parameter for json_encode is typed as an int.