### PR TITLE
Update Core.php

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -867,7 +867,7 @@ class Core
      */
     public static function getNumProcessors()
     {
-        $cmd = "cat /proc/cpuinfo | grep processor | wc -l";
+        $cmd = "nproc --all";
         $numProcessors = intval(shell_exec($cmd));
         return $numProcessors;
     }


### PR DESCRIPTION
Replacing shell command for returning number of processors on host. 

Previous command `cat /proc/cpuinfo | grep processor | wc -l`  makes the assumption that the word "processor" only appears once per processor within the `/proc/cpuinfo`  file.  However testing on different distros has revealed that sometime the word processor appears more than once per processor: eg 
```
 processor       : 1
vendor_id       : GenuineIntel
cpu family      : 15
model           : 6
model name      : Common KVM processor
stepping        : 1
microcode       : 0x1
cpu MHz         : 2194.842
cache size      : 16384 KB
physical id     : 0
siblings        : 2
core id         : 1
cpu cores       : 2
apicid          : 1
initial apicid  : 1
fpu             : yes
fpu_exception   : yes
cpuid level     : 13
wp              : yes
flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx lm constant_tsc nopl xtopology cpuid tsc_known_freq pni cx16 x2apic hypervisor lahf_lm cpuid_fault pti
bugs            : cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds swapgs itlb_multihit mmio_unknown
bogomips        : 4389.68
clflush size    : 64
cache_alignment : 128
address sizes   : 40 bits physical, 48 bits virtual
power management:
```
Note contents of "model name" param.

Found this on proxmox managed vm.  This was causing the method to return twice the actual value, which was leading to memory overloads.